### PR TITLE
fix(projen-eslint): add tsconfig.*.json to .eslintignore

### DIFF
--- a/packages/projen-config/src/projen-eslint.ts
+++ b/packages/projen-config/src/projen-eslint.ts
@@ -97,6 +97,7 @@ export class EslintConfig {
           '.eslintrc.js',
           '*.png',
           'tsconfig.json',
+          'tsconfig.*.json',
           ...additionalIgnorePaths,
           ...(options?.ignorePaths ?? []),
         ],


### PR DESCRIPTION
This naming convention is widely used for adding environment-specific tsconfigs, and it is also used by the projen typescript template by default. Not adding this breaks eslint executions like `npx eslint .`.